### PR TITLE
Add ROS2 CAN gateway project skeleton

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup ROS 2
+      uses: ros-tooling/setup-ros@v0.7
+      with:
+        required-ros-distributions: humble
+    - name: Install deps
+      run: sudo apt-get update && sudo apt-get install -y libuwebsockets-dev
+    - name: Build
+      run: colcon build --event-handlers console_cohesion+
+    - name: Test
+      run: colcon test

--- a/README.md
+++ b/README.md
@@ -1,26 +1,11 @@
-# David Alexandre Vaz Ribeiro
-**Areas of Interest:** System Control, Robotics, Embedded Systems, IoT.
+# Autonomous Robot CAN Gateway
 
-**Skills:** C++, Python, ROS, Git, MATLAB and Simulink, Altium, SolidWorks.
+This repository contains a set of ROS 2 packages for bridging and logging CAN
+bus traffic on Ubuntu 22.04 with ROS 2 Humble.
 
-### Repository summary:
-- [Robotics_4_Farmers CAN Debugger (Embedded C++)](https://github.com/VazRibeiro/Robotics_4_Farmers_CAN_Debugger)
-- [FastSlam (Python)](https://github.com/VazRibeiro/fastSLAM)
-- [Office Lights Distributed Control (Embedded C++)](https://github.com/VazRibeiro/Office-Light-Distributed-Real-Time-Control)
+Packages:
+- **can_gateway** – lifecycle node interfacing SocketCAN.
+- **stream_bridge** – WebSocket server exposing CAN frames.
+- **logging_agent** – simple logging helper.
 
-
-
-<!--
-**VazRibeiro/VazRibeiro** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-
-Here are some ideas to get you started:
-
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+See individual package READMEs for usage.

--- a/can_gateway/CMakeLists.txt
+++ b/can_gateway/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.8)
+project(can_gateway)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(can_msgs REQUIRED)
+find_package(diagnostic_updater REQUIRED)
+
+add_library(${PROJECT_NAME} SHARED
+rosidl_get_typesupport_target(cpp ${PROJECT_NAME}_interfaces "rosidl_typesupport_cpp")
+rosidl_generate_interfaces(${PROJECT_NAME}_interfaces srv/SendFrame.srv DEPENDENCIES can_msgs)
+  src/can_gateway_node.cpp
+  src/diagnostics.cpp)
+
+ament_target_dependencies(${PROJECT_NAME}
+  rclcpp rclcpp_lifecycle can_msgs diagnostic_updater)
+
+target_compile_features(${PROJECT_NAME} PUBLIC c_std_17 cxx_std_17)
+
+add_executable(can_gateway_node src/main.cpp)
+ament_target_dependencies(can_gateway_node rclcpp rclcpp_lifecycle)
+
+target_link_libraries(can_gateway_node ${PROJECT_NAME})
+
+install(TARGETS ${PROJECT_NAME} can_gateway_node
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+install(DIRECTORY include/
+  DESTINATION include)
+
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}/)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_gateway test/test_gateway.cpp)
+  target_link_libraries(test_gateway ${PROJECT_NAME})
+endif()
+
+install(DIRECTORY srv DESTINATION share/${PROJECT_NAME}/srv)
+ament_package()

--- a/can_gateway/README.md
+++ b/can_gateway/README.md
@@ -1,0 +1,19 @@
+# CAN Gateway
+
+ROS2 Lifecycle node that bridges a SocketCAN interface to ROS topics.
+
+## Build
+
+```
+source /opt/ros/humble/setup.bash
+colcon build --packages-select can_gateway
+```
+
+## Usage with vcan
+
+```
+sudo modprobe vcan
+sudo ip link add dev vcan0 type vcan
+sudo ip link set up vcan0
+ros2 launch can_gateway gateway.launch.py interface:=vcan0
+```

--- a/can_gateway/include/can_gateway/can_gateway_node.hpp
+++ b/can_gateway/include/can_gateway/can_gateway_node.hpp
@@ -1,0 +1,50 @@
+#ifndef CAN_GATEWAY_NODE_HPP
+#define CAN_GATEWAY_NODE_HPP
+
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+#include <can_msgs/msg/frame.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
+#include "can_gateway/srv/send_frame.hpp"
+#include <thread>
+#include <atomic>
+
+namespace can_gateway
+{
+class CanGatewayNode : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  explicit CanGatewayNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State & state) override;
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State & state) override;
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State & state) override;
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_cleanup(const rclcpp_lifecycle::State & state) override;
+
+private:
+  void poll_loop();
+  void handle_tx(const can_msgs::msg::Frame::SharedPtr msg);
+  bool send_service(
+    const std::shared_ptr<can_gateway::srv::SendFrame::Request> req,
+    std::shared_ptr<can_gateway::srv::SendFrame::Response> res);
+  void produce_diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat);
+
+  int sock_{-1};
+  std::string interface_;
+  std::thread poll_thread_;
+  std::atomic<bool> running_{false};
+
+  rclcpp_lifecycle::LifecyclePublisher<can_msgs::msg::Frame>::SharedPtr pub_raw_;
+  rclcpp::Subscription<can_msgs::msg::Frame>::SharedPtr sub_tx_;
+  rclcpp::Service<can_gateway::srv::SendFrame>::SharedPtr srv_send_;
+  diagnostic_updater::Updater updater_;
+};
+}  // namespace can_gateway
+
+#endif  // CAN_GATEWAY_NODE_HPP

--- a/can_gateway/launch/gateway.launch.py
+++ b/can_gateway/launch/gateway.launch.py
@@ -1,0 +1,16 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.substitutions import LaunchConfiguration
+
+
+def generate_launch_description():
+    interface = LaunchConfiguration('interface', default='can0')
+    return LaunchDescription([
+        Node(
+            package='can_gateway',
+            executable='can_gateway_node',
+            name='can_gateway',
+            parameters=[{'interface': interface}],
+            output='screen')
+    ])
+

--- a/can_gateway/package.xml
+++ b/can_gateway/package.xml
@@ -1,0 +1,16 @@
+<package format="3">
+  <name>can_gateway</name>
+  <version>0.1.0</version>
+  <description>SocketCAN gateway lifecycle node.</description>
+  <maintainer email="example@example.com">Auto Bot</maintainer>
+  <license>Apache-2.0</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>can_msgs</depend>
+  <depend>diagnostic_updater</depend>
+  <depend>rosidl_default_runtime</depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+</package>

--- a/can_gateway/src/can_gateway_node.cpp
+++ b/can_gateway/src/can_gateway_node.cpp
@@ -1,0 +1,138 @@
+#include "can_gateway/can_gateway_node.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <sys/socket.h>
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include "can_gateway/srv/send_frame.hpp"
+#include <unistd.h>
+#include <fcntl.h>
+#include <cstring>
+using namespace std::chrono_literals;
+
+namespace can_gateway
+{
+
+CanGatewayNode::CanGatewayNode(const rclcpp::NodeOptions & options)
+: rclcpp_lifecycle::LifecycleNode("can_gateway", options)
+{
+  declare_parameter("interface", "can0");
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+CanGatewayNode::on_configure(const rclcpp_lifecycle::State &)
+{
+  interface_ = get_parameter("interface").as_string();
+  sock_ = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+  if (sock_ < 0) {
+    RCLCPP_ERROR(get_logger(), "Failed to open socket: %s", strerror(errno));
+    return CallbackReturn::FAILURE;
+  }
+  int flags = fcntl(sock_, F_GETFL, 0);
+  fcntl(sock_, F_SETFL, flags | O_NONBLOCK);
+  struct ifreq ifr{};
+  std::strncpy(ifr.ifr_name, interface_.c_str(), IFNAMSIZ - 1);
+  if (ioctl(sock_, SIOCGIFINDEX, &ifr) < 0) {
+    RCLCPP_ERROR(get_logger(), "ioctl SIOCGIFINDEX failed");
+    return CallbackReturn::FAILURE;
+  }
+  struct sockaddr_can addr{};
+  addr.can_family = AF_CAN;
+  addr.can_ifindex = ifr.ifr_ifindex;
+  if (bind(sock_, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) < 0) {
+    RCLCPP_ERROR(get_logger(), "bind failed");
+    return CallbackReturn::FAILURE;
+  }
+  pub_raw_ = create_publisher<can_msgs::msg::Frame>("/can/raw", rclcpp::SensorDataQoS());
+  sub_tx_ = create_subscription<can_msgs::msg::Frame>("/can/tx", rclcpp::SensorDataQoS(),
+      std::bind(&CanGatewayNode::handle_tx, this, std::placeholders::_1));
+  srv_send_ = create_service<can_gateway::srv::SendFrame>("send_frame",
+      std::bind(&CanGatewayNode::send_service, this, std::placeholders::_1, std::placeholders::_2));
+  updater_.setHardwareID(interface_);
+  updater_.add("can_stats", this, &CanGatewayNode::produce_diagnostics);
+  return CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+CanGatewayNode::on_activate(const rclcpp_lifecycle::State &)
+{
+  running_.store(true);
+  pub_raw_->on_activate();
+  poll_thread_ = std::thread(&CanGatewayNode::poll_loop, this);
+  return CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+CanGatewayNode::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  running_.store(false);
+  if (poll_thread_.joinable()) {
+    poll_thread_.join();
+  }
+  pub_raw_->on_deactivate();
+  return CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+CanGatewayNode::on_cleanup(const rclcpp_lifecycle::State &)
+{
+  if (sock_ >= 0) {
+    close(sock_);
+    sock_ = -1;
+  }
+  return CallbackReturn::SUCCESS;
+}
+
+void CanGatewayNode::handle_tx(const can_msgs::msg::Frame::SharedPtr msg)
+{
+  struct can_frame frame{};
+  frame.can_id = msg->id;
+  frame.can_dlc = msg->dlc;
+  std::memcpy(frame.data, msg->data.data(), msg->dlc);
+  send(sock_, &frame, sizeof(frame), 0);
+}
+
+bool CanGatewayNode::send_service(
+  const std::shared_ptr<can_gateway::srv::SendFrame::Request> req,
+  std::shared_ptr<can_gateway::srv::SendFrame::Response> res)
+{
+  struct can_frame frame{};
+  frame.can_id = req->frame.id;
+  frame.can_dlc = req->frame.dlc;
+  std::memcpy(frame.data, req->frame.data.data(), req->frame.dlc);
+  if (send(sock_, &frame, sizeof(frame), 0) < 0) {
+    res->success = false;
+    res->message = "send failed";
+  } else {
+    res->success = true;
+    res->message = "sent";
+  }
+  return true;
+}
+
+void CanGatewayNode::poll_loop()
+{
+  struct can_frame frame{};
+  rclcpp::WallRate rate(1ms);
+  while (running_.load()) {
+    int n = recv(sock_, &frame, sizeof(frame), 0);
+    if (n == sizeof(frame)) {
+      auto msg = can_msgs::msg::Frame();
+      msg.id = frame.can_id;
+      msg.dlc = frame.can_dlc;
+      msg.data.assign(frame.data, frame.data + frame.can_dlc);
+      pub_raw_->publish(msg);
+    }
+    updater_.force_update();
+    rate.sleep();
+  }
+}
+
+void CanGatewayNode::produce_diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  // simple placeholder diagnostics
+  stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "ok");
+}
+
+}  // namespace can_gateway

--- a/can_gateway/src/diagnostics.cpp
+++ b/can_gateway/src/diagnostics.cpp
@@ -1,0 +1,6 @@
+#include "can_gateway/can_gateway_node.hpp"
+
+namespace can_gateway
+{
+// additional diagnostic helpers could be placed here
+}

--- a/can_gateway/src/main.cpp
+++ b/can_gateway/src/main.cpp
@@ -1,0 +1,14 @@
+#include "can_gateway/can_gateway_node.hpp"
+#include <rclcpp/rclcpp.hpp>
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto options = rclcpp::NodeOptions();
+  auto node = std::make_shared<can_gateway::CanGatewayNode>(options);
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node->get_node_base_interface());
+  exec.spin();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/can_gateway/srv/SendFrame.srv
+++ b/can_gateway/srv/SendFrame.srv
@@ -1,0 +1,4 @@
+can_msgs/Frame frame
+---
+bool success
+string message

--- a/can_gateway/test/test_gateway.cpp
+++ b/can_gateway/test/test_gateway.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+#include "can_gateway/can_gateway_node.hpp"
+
+TEST(CanGateway, construct)
+{
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<can_gateway::CanGatewayNode>();
+  ASSERT_NE(node, nullptr);
+  rclcpp::shutdown();
+}

--- a/logging_agent/CMakeLists.txt
+++ b/logging_agent/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.8)
+project(logging_agent)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(can_msgs REQUIRED)
+
+add_executable(logging_agent_node src/logging_agent.cpp)
+ament_target_dependencies(logging_agent_node rclcpp can_msgs)
+
+install(TARGETS logging_agent_node
+  DESTINATION lib/${PROJECT_NAME})
+
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/logging_agent/launch/logging.launch.py
+++ b/logging_agent/launch/logging.launch.py
@@ -1,0 +1,12 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='logging_agent',
+            executable='logging_agent_node',
+            name='logging_agent',
+            output='screen')
+    ])

--- a/logging_agent/package.xml
+++ b/logging_agent/package.xml
@@ -1,0 +1,13 @@
+<package format="3">
+  <name>logging_agent</name>
+  <version>0.1.0</version>
+  <description>Logging agent for CAN frames.</description>
+  <maintainer email="example@example.com">Auto Bot</maintainer>
+  <license>Apache-2.0</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>can_msgs</depend>
+  <depend>moodycamel</depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+</package>

--- a/logging_agent/src/logging_agent.cpp
+++ b/logging_agent/src/logging_agent.cpp
@@ -1,0 +1,12 @@
+#include <rclcpp/rclcpp.hpp>
+#include <can_msgs/msg/frame.hpp>
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("logging_agent");
+  RCLCPP_INFO(node->get_logger(), "logging agent started");
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/net_docs/setup_wireguard.md
+++ b/net_docs/setup_wireguard.md
@@ -1,0 +1,15 @@
+# WireGuard Setup
+
+Example configuration for WireGuard on Ubuntu 22.04.
+
+```
+[Interface]
+PrivateKey = <your private key>
+Address = 10.0.0.1/24
+ListenPort = 51820
+
+[Peer]
+PublicKey = <peer public key>
+AllowedIPs = 10.0.0.2/32
+Endpoint = example.com:51820
+```

--- a/stream_bridge/CMakeLists.txt
+++ b/stream_bridge/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.8)
+project(stream_bridge)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(can_msgs REQUIRED)
+
+add_executable(stream_bridge_node src/bridge.cpp)
+ament_target_dependencies(stream_bridge_node rclcpp can_msgs)
+
+install(TARGETS stream_bridge_node
+  DESTINATION lib/${PROJECT_NAME})
+
+install(DIRECTORY include/
+  DESTINATION include)
+
+install(DIRECTORY launch html
+  DESTINATION share/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/stream_bridge/html/app.js
+++ b/stream_bridge/html/app.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const ws = new WebSocket('wss://' + location.host + '/ws');
+  ws.onmessage = (event) => {
+    console.log('frame', event.data);
+  };
+});

--- a/stream_bridge/html/index.html
+++ b/stream_bridge/html/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CAN Dashboard</title>
+  <script src="app.js"></script>
+</head>
+<body>
+  <h1>CAN Dashboard</h1>
+  <div id="chart"></div>
+</body>
+</html>

--- a/stream_bridge/html/manifest.json
+++ b/stream_bridge/html/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "CAN Dashboard",
+  "short_name": "CAN",
+  "display": "standalone",
+  "start_url": "/index.html"
+}

--- a/stream_bridge/html/sw.js
+++ b/stream_bridge/html/sw.js
@@ -1,0 +1,6 @@
+self.addEventListener('install', event => {
+  event.waitUntil(caches.open('can-cache').then(c => c.addAll(['./', 'index.html', 'app.js'])));
+});
+self.addEventListener('fetch', event => {
+  event.respondWith(caches.match(event.request).then(resp => resp || fetch(event.request)));
+});

--- a/stream_bridge/include/stream_bridge/bridge.hpp
+++ b/stream_bridge/include/stream_bridge/bridge.hpp
@@ -1,0 +1,21 @@
+#ifndef STREAM_BRIDGE_BRIDGE_HPP
+#define STREAM_BRIDGE_BRIDGE_HPP
+
+#include <rclcpp/rclcpp.hpp>
+#include <can_msgs/msg/frame.hpp>
+#include <uWS/uWS.h>
+
+namespace stream_bridge
+{
+class Bridge
+{
+public:
+  Bridge();
+  void run();
+private:
+  rclcpp::Node::SharedPtr node_;
+  uWS::Hub hub_;
+};
+}  // namespace stream_bridge
+
+#endif

--- a/stream_bridge/launch/bridge.launch.py
+++ b/stream_bridge/launch/bridge.launch.py
@@ -1,0 +1,12 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='stream_bridge',
+            executable='stream_bridge_node',
+            name='stream_bridge',
+            output='screen')
+    ])

--- a/stream_bridge/package.xml
+++ b/stream_bridge/package.xml
@@ -1,0 +1,14 @@
+<package format="3">
+  <name>stream_bridge</name>
+  <version>0.1.0</version>
+  <description>WebSocket bridge for CAN frames.</description>
+  <maintainer email="example@example.com">Auto Bot</maintainer>
+  <license>Apache-2.0</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>can_msgs</depend>
+  <depend>uwebsockets</depend>
+  <build_depend>ament_cmake</build_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+</package>

--- a/stream_bridge/src/bridge.cpp
+++ b/stream_bridge/src/bridge.cpp
@@ -1,0 +1,30 @@
+#include "stream_bridge/bridge.hpp"
+#include <uWS/uWS.h>
+
+namespace stream_bridge
+{
+
+Bridge::Bridge()
+{
+  node_ = rclcpp::Node::make_shared("stream_bridge");
+}
+
+void Bridge::run()
+{
+  hub_.onConnection([this](uWS::WebSocket<uWS::SERVER> *ws, uWS::HttpRequest const &){
+    RCLCPP_INFO(node_->get_logger(), "client connected");
+  });
+  hub_.listen(9002);
+  hub_.run();
+}
+
+}  // namespace stream_bridge
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  stream_bridge::Bridge b;
+  b.run();
+  rclcpp::shutdown();
+  return 0;
+}

--- a/systemd/can_gateway.service
+++ b/systemd/can_gateway.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=CAN Gateway
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/ros2 launch can_gateway gateway.launch.py interface=can0
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- start new ROS 2 workspace layout for the CAN gateway project
- implement `can_gateway` lifecycle node with SocketCAN polling thread
- add `stream_bridge` example WebSocket server and PWA dashboard assets
- add `logging_agent` stub node
- provide WireGuard setup docs and systemd service template
- configure CI workflow for colcon build

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y python3-colcon-common-extensions` *(failed: package not found)*
- `colcon build --packages-select can_gateway stream_bridge logging_agent` *(failed: colcon not found)*

------
https://chatgpt.com/codex/tasks/task_e_68508b8ad7548324b89f8af003b495e3